### PR TITLE
[Fixed] Feature/issues 1

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -13,12 +13,22 @@ class AssignsController < ApplicationController
       redirect_to team_url(team), notice: I18n.t('views.messages.failed_to_assign')
     end
   end
+#Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
 
   def destroy
     assign = Assign.find(params[:id])
-    destroy_message = assign_destroy(assign, assign.user)
+    if assign.user == assign.team.owner
+      destroy_message = assign_destroy(assign, assign.user)
+      redirect_to team_url(params[:team_id]), notice: destroy_message
+    elsif assign.user == current_user
+      destroy_message = assign_destroy(assign, assign.user)
+      redirect_to team_url(params[:team_id]), notice: destroy_message
+    else
+      redirect_to team_url(params[:team_id]), notice: "削除できません"
+    end
+    # destroy_message = assign_destroy(assign, assign.user)
 
-    redirect_to team_url(params[:team_id]), notice: destroy_message
+    # redirect_to team_url(params[:team_id]), notice: destroy_message
   end
 
   private

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,8 +15,12 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
-
+  def edit
+    #TeamのeditはTeamのリーダー（オーナー）のみができるようにすること
+    if @team.owner_id != current_user.id
+      redirect_to @team, notice: '編集できません'
+    end
+  end
   def create
     @team = Team.new(team_params)
     @team.owner = current_user

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -5,5 +5,6 @@ class Article < ApplicationRecord
   belongs_to :team
   belongs_to :agenda
   has_many :comments, dependent: :destroy
+  
   mount_uploader :image, ImageUploader
 end


### PR DESCRIPTION
TeamのeditはTeamのリーダー（オーナー）のみができるようにすること
Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること

完了